### PR TITLE
fix: card details [DHIS2-18389] 

### DIFF
--- a/src/components/Details/Content.js
+++ b/src/components/Details/Content.js
@@ -46,12 +46,16 @@ export const contentItems = [
         label: 'Tracked Entity Attribute',
     },
     {
-        value: 'user',
+        value: 'userId',
         label: 'User ID',
     },
     {
         value: 'userGroups',
         label: 'User groups',
+    },
+    {
+        value: 'userRoles',
+        label: 'User roles',
     },
 ]
 

--- a/src/components/Details/DetailsContent.js
+++ b/src/components/Details/DetailsContent.js
@@ -46,7 +46,7 @@ CompletedTime.propTypes = {
 }
 
 const ExpandableContent = ({ isLatestRun, finishedTime, children }) => {
-    const [isExpanded, setIsExpanded] = useState(false)
+    const [isExpanded, setIsExpanded] = useState(isLatestRun)
 
     const toggleExpand = useCallback(() => {
         setIsExpanded((prevExpanded) => !prevExpanded)

--- a/src/components/Details/DetailsContent.js
+++ b/src/components/Details/DetailsContent.js
@@ -12,10 +12,14 @@ const CompletedTime = ({ finishedTime, latest }) => {
     const { fromServerDate } = useTimeZoneConversion()
     const latestRun = fromServerDate(finishedTime)
 
-    const formattedLatestRun = Intl.DateTimeFormat([selectedLocale], {
+    const formattedDate = Intl.DateTimeFormat([selectedLocale], {
         dateStyle: 'short',
-        timeStyle: 'short',
+        timeStyle: 'medium',
+        hour12: false,
     }).format(latestRun)
+
+    const milliseconds = String(latestRun.getMilliseconds()).padStart(3, '0')
+    const formattedLatestRun = `${formattedDate}.${milliseconds}`
 
     return (
         <span
@@ -41,7 +45,7 @@ CompletedTime.propTypes = {
     latest: PropTypes.bool,
 }
 
-const ExpandableContent = ({ isLatestRun, artifact, children }) => {
+const ExpandableContent = ({ isLatestRun, finishedTime, children }) => {
     const [isExpanded, setIsExpanded] = useState(false)
 
     const toggleExpand = useCallback(() => {
@@ -56,7 +60,7 @@ const ExpandableContent = ({ isLatestRun, artifact, children }) => {
                 role="button"
             >
                 <CompletedTime
-                    finishedTime={artifact.finished}
+                    finishedTime={finishedTime}
                     latest={isLatestRun}
                 />
                 {isExpanded ? <IconChevronUp24 /> : <IconChevronDown24 />}
@@ -68,10 +72,7 @@ const ExpandableContent = ({ isLatestRun, artifact, children }) => {
 
 ExpandableContent.propTypes = {
     isLatestRun: PropTypes.bool,
-    artifact: PropTypes.shape({
-        finished: PropTypes.string,
-        message: PropTypes.string,
-    }),
+    finishedTime: PropTypes.string,
     children: PropTypes.node,
 }
 
@@ -82,7 +83,7 @@ export const DetailsContent = ({ artifact }) => {
                 <ExpandableContent
                     key={index}
                     isLatestRun={index === 0}
-                    artifact={artifact}
+                    finishedTime={error.finished}
                 >
                     <Content artifact={artifact} error={error} />
                 </ExpandableContent>

--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -2,6 +2,7 @@ import i18n from '@dhis2/d2-i18n'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { memo } from 'react'
+import { EVENT } from '../../shared'
 import { LastRunTime } from './LastRunTime'
 import css from './List.module.css'
 import { StatusIcon } from './StatusIcon'
@@ -26,8 +27,6 @@ List.propTypes = {
     artifacts: PropTypes.array,
     selectedArtifact: PropTypes.object,
 }
-
-const EVENT = 'event'
 
 export const ListItem = memo(function ListItem({
     setSelectedArtifact,

--- a/src/components/Toolbar/ToolbarTabs.js
+++ b/src/components/Toolbar/ToolbarTabs.js
@@ -2,10 +2,8 @@ import i18n from '@dhis2/d2-i18n'
 import { Tab, TabBar } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { EVENT, TRACKER } from '../../shared'
 import css from './Toolbar.module.css'
-
-export const EVENT = 'event'
-export const TRACKER = 'tracker'
 
 export const ToolbarTabs = ({ selectedTab, setSelectedTab }) => {
     return (

--- a/src/page/Troubleshooting/ErrorList/ErrorList.js
+++ b/src/page/Troubleshooting/ErrorList/ErrorList.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import {
     DetailsView,
     ErrorOrLoading,
-    EVENT,
     filterSearchElements,
     Layout,
     List,
@@ -12,6 +11,7 @@ import {
     Toolbar,
     ToolbarTabs,
 } from '../../../components'
+import { EVENT } from '../../../shared'
 import css from './List.module.css'
 import { useJobErrors } from './useJobErrors'
 

--- a/src/page/Troubleshooting/ErrorList/useJobErrors.js
+++ b/src/page/Troubleshooting/ErrorList/useJobErrors.js
@@ -1,5 +1,6 @@
 import { useDataQuery } from '@dhis2/app-runtime'
 import { useState, useEffect } from 'react'
+import { EVENT, TRACKER, WITHOUT_REGISTRATION } from '../../../shared'
 
 const errorQuery = {
     errors: {
@@ -119,9 +120,7 @@ export const useJobConfigurationErrors = () => {
 const getEventData = (error, events) => {
     const currentEvent = events?.find((e) => e.event === error.id)
     const type =
-        currentEvent?.programType === 'WITHOUT_REGISTRATION'
-            ? 'event'
-            : 'tracker'
+        currentEvent?.programType === WITHOUT_REGISTRATION ? EVENT : TRACKER
 
     return {
         ...currentEvent,
@@ -173,8 +172,7 @@ const getUserInfo = (userId, key, users) => {
 const getProgramAndStage = (programId, stageId, programs) => {
     const program = programs?.find((p) => p.id === programId)
     const programStage = program?.programStages?.find((ps) => ps.id === stageId)
-    const type =
-        program?.programType === 'WITHOUT_REGISTRATION' ? 'event' : 'tracker'
+    const type = program?.programType === WITHOUT_REGISTRATION ? EVENT : TRACKER
 
     return {
         programName: program?.displayName || null,

--- a/src/page/Troubleshooting/ErrorList/useJobErrors.js
+++ b/src/page/Troubleshooting/ErrorList/useJobErrors.js
@@ -32,6 +32,7 @@ const usersQuery = {
                 'name',
                 'displayName',
                 'userGroups[id,name,displayName]',
+                'userRoles[id,name,displayName]',
             ],
         }),
     },
@@ -204,6 +205,7 @@ const prepareErrorList = ({ errors, events, programs, users }) => {
                 finished: item.finished,
                 jobId: item.id,
                 user: currentUser?.displayName || item.user,
+                userId: item.user,
                 status: 'Error',
                 type: type || null,
                 orgUnit: eventElements?.orgUnit || null,
@@ -212,6 +214,7 @@ const prepareErrorList = ({ errors, events, programs, users }) => {
                 programStage: programStageName || eventElements?.programStage,
                 event: entry.id,
                 userGroups: getUserInfo(item.user, 'userGroups', users),
+                userRoles: getUserInfo(item.user, 'userRoles', users),
             }
         })
     )


### PR DESCRIPTION
**Implements** [DHIS2-18389](https://dhis2.atlassian.net/browse/DHIS2-18389)

---

### Key features

1. _Open Last Error panel by default_
2. _Show Minutes and Milliseconds in Timestamp_
3. _Add User Role and UserID to details_

---

### Description

- Add extra attributes to the card details like `User Role` and `User Id`.
- **Open Last Error Panel by Default:** When expanding an error group, it would improve usability if the last error’s red error box opened by default. This could streamline the review process for users by highlighting the latest issue immediately.
- **Show Minutes and Milliseconds in Timestamp:** To provide more precise time tracking, please display both the minute and millisecond in timestamps. This additional granularity is crucial for accurate event logging. `hh:mm:ss.SSS`

---

### Screenshots

_format Timestamp_
![image](https://github.com/user-attachments/assets/d550a253-2a03-4797-960c-8d7b02b48227)

_user role and user id in card details_
![image](https://github.com/user-attachments/assets/3cec256a-1d27-437e-87c1-d1928485afde)

_last error card open_
![image](https://github.com/user-attachments/assets/864ba73b-36f9-4078-a6d8-6df1ef53640f)


[DHIS2-18389]: https://dhis2.atlassian.net/browse/DHIS2-18389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ