### PR TITLE
style: add multiline ellipsis for long errors [DHIS2-19032]

### DIFF
--- a/src/components/List/List.js
+++ b/src/components/List/List.js
@@ -42,7 +42,9 @@ export const ListItem = memo(function ListItem({
             onClick={() => setSelectedArtifact(artifact)}
         >
             <div className={css.artifactInfo}>
-                <span className={css.header}>{artifact.message}</span>
+                <span className={cx(css.header, css.ellipsisMultiline)}>
+                    {artifact.message}
+                </span>
                 <div className={css.subtitle}>
                     <span>{getType(artifact.type)}</span>
                     <VerticalDivider />

--- a/src/components/List/List.module.css
+++ b/src/components/List/List.module.css
@@ -18,6 +18,16 @@
     font-weight: 500;
 }
 
+.ellipsisMultiline {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    word-break: break-word; /* Prevent long words from causing overflow */
+    max-width: 100%;
+}
+
 .listItem .artifactInfo {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
**Implements** [DHIS2-19032](https://dhis2.atlassian.net/browse/DHIS2-19032)

---

### Description

Adding multi line ellipsis for long errors preventing overflows. Long errors can cause the container to expand beyond its intended width, affecting the alignment of other elements like the status icon.

---

### Screenshots

_Long message with ellipsis (chrome)_
![image](https://github.com/user-attachments/assets/e9905206-e5b1-4272-944d-12d0a9c1ab1a)

_Long message with ellipsis (firefox)_
![image](https://github.com/user-attachments/assets/f6c26938-1a2f-4511-9363-4562c6fb0528)

_Long message and details_
![image](https://github.com/user-attachments/assets/23b51751-3279-42b7-8ae9-2e9afa7e3c0a)


[DHIS2-19032]: https://dhis2.atlassian.net/browse/DHIS2-19032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ